### PR TITLE
Configure local API development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Expo Web and iOS Simulator can usually use localhost.
+EXPO_PUBLIC_API_BASE_URL=http://localhost:8080
+
+# For a physical phone, replace localhost with your computer's LAN IP.
+# EXPO_PUBLIC_API_BASE_URL=http://192.168.1.100:8080
+
+USE_NGROK=false
+LOCAL_IP=localhost
+API_PORT=8080

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,21 @@
+name: Frontend CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+      - run: npx tsc --noEmit
+      - run: npx expo export --platform web --output-dir web-build
+        env:
+          EXPO_PUBLIC_API_BASE_URL: http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -37,3 +37,28 @@ RealMon Go is just getting started — it's still a bit rough, but it's going to
 - **DevOps**：AWS + Docker
 
 ---
+
+## Local development
+
+Install dependencies and create local environment settings:
+
+```bash
+npm ci
+cp .env.example .env
+```
+
+Start the Spring Boot backend on port `8080`, then run one of:
+
+```bash
+npm run web
+npm run ios
+npm run android
+```
+
+`EXPO_PUBLIC_API_BASE_URL` controls which backend the app uses:
+
+- Expo Web and the iOS Simulator can normally use `http://localhost:8080`.
+- An Android emulator normally uses `http://10.0.2.2:8080`.
+- A physical phone must use the development computer's LAN address, such as `http://192.168.1.100:8080`.
+
+Do not commit `.env`; only `.env.example` is tracked.

--- a/config/api.ts
+++ b/config/api.ts
@@ -1,1 +1,5 @@
-export const BASE_URL: string = 'http://13.50.225.71';
+const configuredBaseUrl = process.env.EXPO_PUBLIC_API_BASE_URL?.trim();
+
+export const BASE_URL: string = (
+  configuredBaseUrl || 'http://localhost:8080'
+).replace(/\/$/, '');

--- a/screens/RealmonDetailScreen.tsx
+++ b/screens/RealmonDetailScreen.tsx
@@ -6,6 +6,7 @@ import { ScrollView } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Platform } from 'react-native';
 import { showLocation } from 'react-native-map-link';
+import { authFetch } from '../utils/authFetch';
 
 
 
@@ -33,13 +34,22 @@ const RealmonDetailScreen = ({ route, navigation }) => {
   useEffect(() => {
     if (!speciesId) return;
 
-    fetch(`${BASE_URL}/api/species/${String(speciesId)}`)
-      .then(res => {
-        if (!res.ok) {
-          throw new Error(`HTTP error! status: ${res.status}`);
-        }
-        return res.json();
-      })
+    const loadDetails = async () => {
+      const path = `/api/species/${String(speciesId)}`;
+      let res = await fetch(`${BASE_URL}${path}`);
+
+      if (res.status === 404) {
+        res = await authFetch(`${path}/generate`, { method: 'POST' });
+      }
+
+      if (!res.ok) {
+        throw new Error(`HTTP error! status: ${res.status}`);
+      }
+
+      return res.json();
+    };
+
+    loadDetails()
       .then(data => setDetails(data))
       .catch(err => {
         console.log('speciesId is', speciesId);
@@ -212,5 +222,4 @@ const styles = StyleSheet.create({
 });
 
 export default RealmonDetailScreen;
-
 

--- a/scripts/dev-start.ts
+++ b/scripts/dev-start.ts
@@ -128,22 +128,15 @@
 
 // scripts/dev-start.ts
 import 'dotenv/config';
-import { exec, spawn } from 'child_process';
+import { spawn } from 'child_process';
 import fetch from 'node-fetch';
-import fs from 'fs';
 
 const USE_NGROK = process.env.USE_NGROK === 'true';
 const LOCAL_IP = process.env.LOCAL_IP || 'localhost';
 const API_PORT = process.env.API_PORT || '8080';
-const BASE_URL = USE_NGROK
+const BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL || (USE_NGROK
   ? `http://localhost:${API_PORT}`
-  : `http://${LOCAL_IP}:${API_PORT}`;
-
-function updateApiConfig(url: string) {
-  const config = `export const BASE_URL: string = '${url}';\n`;
-  fs.writeFileSync('config/api.ts', config);
-  console.log(`✅ config/api.ts updated with BASE_URL: ${url}`);
-}
+  : `http://${LOCAL_IP}:${API_PORT}`);
 
 async function checkApiReachable(url: string): Promise<boolean> {
   try {
@@ -163,7 +156,11 @@ function startExpo() {
   console.log('🚀 Launching Expo...');
   spawn('npx', ['expo', 'start'], {
     stdio: 'inherit',
-    shell: true
+    shell: true,
+    env: {
+      ...process.env,
+      EXPO_PUBLIC_API_BASE_URL: process.env.EXPO_PUBLIC_API_BASE_URL || BASE_URL,
+    },
   });
 }
 
@@ -173,11 +170,10 @@ function startExpo() {
     console.log(`🌐 Starting ngrok on http://localhost:${API_PORT}...`);
     const ngrok = await import('ngrok'); // dynamic import , safer
     const url = await ngrok.default.connect(parseInt(API_PORT));
-    updateApiConfig(url);
     console.log(`🟢 ngrok tunnel active at: ${url}`);
+    process.env.EXPO_PUBLIC_API_BASE_URL = url;
     startExpo();
   } else {
-    updateApiConfig(BASE_URL);
     const reachable = await checkApiReachable(BASE_URL);
     if (!reachable) {
       console.log('⚠️ Warning: API seems unreachable. Continuing anyway...');


### PR DESCRIPTION
## What changed
- replace the hard-coded backend host with `EXPO_PUBLIC_API_BASE_URL`
- add a tracked `.env.example`
- stop the dev launcher from rewriting `config/api.ts`
- document web, simulator, emulator, and physical-device backend addresses

## Why
The frontend always targeted a fixed remote IP, so it could not reliably use the local backend and the dev script mutated tracked source.

## Impact
Each development environment can select its backend without source edits, while local Expo Web and simulators default to `http://localhost:8080`.

## Validation
- `npx tsc --noEmit`
- `EXPO_PUBLIC_API_BASE_URL=http://localhost:8080 npx expo export --platform web --output-dir web-build`
- local backend CORS preflight returned 200