### PR TITLE
Remove sensitive authentication logs

### DIFF
--- a/screens/AuthGate.tsx
+++ b/screens/AuthGate.tsx
@@ -16,7 +16,6 @@ export default function AuthGate() {
     (async () => {
       try {
         const token = await AsyncStorage.getItem('token');
-        console.log("🔍 AuthGate: token =", token);
         if (!token) {
           console.log("❌ No token found, redirecting to Login");
           navigation.replace('Login');

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -188,7 +188,6 @@ export default function HomeScreen() {
   //       }
   
   //       const { data: token } = await Notifications.getExpoPushTokenAsync();
-  //       console.log("✅ HomeScreen: Got Expo Push Token:", token);
   //     } catch (e) {
   //       console.error("❌ HomeScreen: Error getting push token:", e);
   //     }
@@ -438,5 +437,4 @@ const styles = StyleSheet.create({
   },
   title: { fontSize: 20, marginBottom: 20 },
 });
-
 

--- a/screens/LoginScreen.tsx
+++ b/screens/LoginScreen.tsx
@@ -57,7 +57,6 @@
 //     };
 
 //     try {
-//       console.log(`🚀 Sending login request to ${BASE_URL}/api/user/login with:`, { username, password });
 //       const res = await fetch(`${BASE_URL}/api/user/login`, {
 //         method: 'POST',
 //         headers: { 'Content-Type': 'application/json' },
@@ -67,7 +66,6 @@
       
 //       console.log("✅ Fetch completed. Status:", res.status);
 //       const text = await res.text();
-//       console.log("📜 Raw response:", text);
 
 //       if (res.status === 401) {
 //         Alert.alert('Login failed', 'Invalid username or password');
@@ -209,20 +207,14 @@ export default function LoginScreen() {
     }
 
     setLoading(true);
-    console.log("🚀 BASE_URL in runtime:", BASE_URL);
-
     try {
-      console.log(`🚀 Sending login request to ${BASE_URL}/api/user/login with:`, { username, password });
-
       const res = await fetch(`${BASE_URL}/api/user/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password }),
       });
 
-      console.log("✅ Fetch completed. Status:", res.status);
       const rawText = await res.text();
-      console.log("📜 Raw response:", rawText);
 
       if (res.status === 401) {
         Alert.alert('Login failed', 'Invalid username or password');

--- a/utils/authFetch.ts
+++ b/utils/authFetch.ts
@@ -7,8 +7,6 @@ export const authFetch = async (
 ): Promise<Response> => {
   try {
     const token = await AsyncStorage.getItem('token');
-    console.log("token is", token);
-
     const headers = {
       ...(options.headers || {}),
       'Content-Type': 'application/json',
@@ -26,4 +24,3 @@ export const authFetch = async (
     throw err;
   }
 };
-


### PR DESCRIPTION
## What changed
- remove runtime logging of login credentials and raw login responses
- remove JWT logging from authentication bootstrap and authenticated fetches
- remove stale commented push-token logging

## Why
Authentication credentials and tokens could appear in development logs, browser consoles, device logs, or captured diagnostics.

## Impact
Login and authenticated requests behave the same, but sensitive authentication material is no longer written to logs.

## Validation
- `npx tsc --noEmit`
- `EXPO_PUBLIC_API_BASE_URL=http://localhost:8080 npx expo export --platform web --output-dir web-build`